### PR TITLE
Update auto.ron

### DIFF
--- a/data/auto.ron
+++ b/data/auto.ron
@@ -11,6 +11,7 @@
     "amsynth",
     "gnome-shell",
     "kwin",
+    "lutris",
     "sway",
     "steam",
     "vrcompositor",


### PR DESCRIPTION
Adding Lutris to the list. For non-steam games. Like Overwatch.